### PR TITLE
Disable scroll-on-focus in drag focus kludge

### DIFF
--- a/src/edit/mouse_events.js
+++ b/src/edit/mouse_events.js
@@ -159,7 +159,7 @@ function leftButtonStartDrag(cm, event, pos, behavior) {
         extendSelection(cm.doc, pos, null, null, behavior.extend)
       // Work around unexplainable focus problem in IE9 (#2127) and Chrome (#3081)
       if (webkit || ie && ie_version == 9)
-        setTimeout(() => {display.wrapper.ownerDocument.body.focus(); display.input.focus()}, 20)
+        setTimeout(() => {display.wrapper.ownerDocument.body.focus({preventScroll: true}); display.input.focus()}, 20)
       else
         display.input.focus()
     }


### PR DESCRIPTION
Since it causes jumps in the scroll position on Chrome.

Closes #6246